### PR TITLE
fix: [Traits] Fixed Trait inheritance issues

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -128,6 +128,18 @@ Vector<String> ScriptTextEditor::get_functions() {
 		//if valid rewrite functions to latest
 		functions.clear();
 		for (const String &E : fnc) {
+			int line = E.get_slice(":", 1).to_int() - 1;
+
+			// We check if the function really exist in the file (due to the trait system)
+			if (te->get_line_count() < line) {
+				continue;
+			}
+
+			String line_content = te->get_line_wrapped_text(line)[0].strip_edges();
+			String function_name = E.get_slice(":", 0);
+			if (!line_content.begins_with(vformat("func %s", function_name))) {
+				continue;
+			}
 			functions.push_back(E);
 		}
 	}
@@ -563,6 +575,19 @@ void ScriptTextEditor::_validate_script() {
 
 		functions.clear();
 		for (const String &E : fnc) {
+			int line = E.get_slice(":", 1).to_int() - 1;
+
+			// We check if the function really exist in the file (due to the trait system)
+			if (te->get_line_count() < line) {
+				continue;
+			}
+
+			String line_content = te->get_line_wrapped_text(line)[0].strip_edges();
+			String function_name = E.get_slice(":", 0);
+			if (!line_content.begins_with(vformat("func %s", function_name))) {
+				continue;
+			}
+
 			functions.push_back(E);
 		}
 		script_is_valid = true;

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -570,9 +570,8 @@ void ScriptCreateDialog::set_script_menu() {
 void ScriptCreateDialog::_on_script_menu_item_selected(int p_index) {
 	selected_script = p_index;
 	file_path->set_text(_adjust_file_path(file_path->get_text()));
-	path_error = _validate_path(file_path->get_text(), false, false);
+	_path_changed(file_path->get_text());
 	_parent_name_changed(parent_name->get_text());
-	validation_panel->update();
 }
 
 void ScriptCreateDialog::_built_in_pressed() {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -106,6 +106,12 @@ Ref<Script> GDScriptLanguage::make_template_using_extension(const String &p_temp
 									 .replace(" -> Object", "");
 	}
 
+	// Processing the template for the GDTrait
+	if (p_extension == "gdt")
+	{
+		processed_template = processed_template.replace("extends _BASE_", "trait_name _CLASS_ extends _BASE_");
+	}
+
 	processed_template = processed_template.replace("_BASE_", p_base_class_name)
 								 .replace("_CLASS_SNAKE_CASE_", p_class_name.to_snake_case().validate_unicode_identifier())
 								 .replace("_CLASS_", p_class_name.to_pascal_case().validate_unicode_identifier())

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -107,8 +107,7 @@ Ref<Script> GDScriptLanguage::make_template_using_extension(const String &p_temp
 	}
 
 	// Processing the template for the GDTrait
-	if (p_extension == "gdt")
-	{
+	if (p_extension == "gdt") {
 		processed_template = processed_template.replace("extends _BASE_", "trait_name _CLASS_ extends _BASE_");
 	}
 


### PR DESCRIPTION
Fixed things and bugs.
- Now when we create a trait, the first line is "trait_name trait extends parent".
- Methods list now doesn't show non-existant function inherited from the trait.
- Fixed the ability to create 2 GDT with the same name.
- Fixed a gutter icon bug for non-existant function that where inside the trait but not inside the script.
